### PR TITLE
Fix make dmg command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ app:
 	rm -rf dist build; python setup.py py2app
 dmg:
 	make app
-	rm ./AutoVPN.dmg
+	rm -f ./AutoVPN.dmg
 	hdiutil create ./AutoVPN-pre.dmg -ov -volname "AutoVPN" -fs HFS+ -srcfolder "./dist"
 	hdiutil convert ./AutoVPN-pre.dmg -format UDZO -o ./AutoVPN.dmg
 	rm ./AutoVPN-pre.dmg


### PR DESCRIPTION
There is no dmg file in the first run, and the rm command errors out if file is missing. Fixes this by checking existence of the file first